### PR TITLE
chore(hub): update development environment common password

### DIFF
--- a/config/config.dev.json
+++ b/config/config.dev.json
@@ -7,11 +7,11 @@
   },
   "redis": {
     "addr": "localhost:6379",
-    "password": "",
+    "password": "Pa33WoRD",
     "db": 0
   },
   "postgres": {
-    "dsn": "host=localhost port=5432 user=rss3 password=rss3rocks dbname=pregod sslmode=disable TimeZone=UTC",
+    "dsn": "host=localhost port=5432 user=rss3 password=Pa33WoRD dbname=pregod sslmode=disable TimeZone=UTC",
     "max_open_conns": 100,
     "max_idle_conns": 20,
     "conn_max_idle_time": -1,


### PR DESCRIPTION
The password of `local docker development environment` is different from the password in `config.dev.json` of the development environment.

https://github.com/NaturalSelectionLabs/RSS3-PreGod/blob/8024f89e56fc86a606b903146afa53d99f5faffb/docker/docker-compose.dev.yml#L3-L15