### PR TITLE
fix: split auto crawler and API; try fix mem leak

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -124,11 +124,12 @@ jobs:
           cmd: |
             yq -i '.spec.template.spec.containers[0].image = "${{ env.IMAGE_NAME_HUB }}:${{ steps.meta.outputs.version }}"' ./deploy/dev/deploy-hub.yaml
             yq -i '.spec.template.spec.containers[0].image = "${{ env.IMAGE_NAME_INDEXER }}:${{ steps.meta.outputs.version }}"' ./deploy/dev/deploy-indexer.yaml
+            yq -i '.spec.template.spec.containers[0].image = "${{ env.IMAGE_NAME_INDEXER }}:${{ steps.meta.outputs.version }}"' ./deploy/dev/deploy-indexer-autocrawler.yaml
             yq -i '.spec.jobTemplate.spec.template.spec.containers[0].image = "${{ env.IMAGE_NAME_INDEXER }}:${{ steps.meta.outputs.version }}"' ./deploy/dev/cronjob-indexer.yaml
       - run: aws eks update-kubeconfig --region us-west-2 --name development
       - run: |
           kubectl apply -f deploy/dev
-          kubectl -n pregod rollout restart deploy pregod-hub pregod-indexer
+          kubectl -n pregod rollout restart deploy pregod-hub pregod-indexer pregod-indexer-autocrawler
           kubectl -n pregod rollout status deploy pregod-hub
           kubectl -n pregod rollout status deploy pregod-indexer
 
@@ -156,9 +157,11 @@ jobs:
           cmd: |
             yq -i '.spec.template.spec.containers[0].image = "${{ env.IMAGE_NAME_HUB }}:${{ steps.meta.outputs.version }}"' ./deploy/prod/deploy-hub.yaml
             yq -i '.spec.template.spec.containers[0].image = "${{ env.IMAGE_NAME_INDEXER }}:${{ steps.meta.outputs.version }}"' ./deploy/prod/deploy-indexer.yaml
+            yq -i '.spec.template.spec.containers[0].image = "${{ env.IMAGE_NAME_INDEXER }}:${{ steps.meta.outputs.version }}"' ./deploy/dev/deploy-indexer-autocrawler.yaml
             yq -i '.spec.jobTemplate.spec.template.spec.containers[0].image = "${{ env.IMAGE_NAME_INDEXER }}:${{ steps.meta.outputs.version }}"' ./deploy/prod/cronjob-indexer.yaml
       - run: aws eks update-kubeconfig --region us-west-2 --name production
       - run: |
           kubectl apply -f deploy/prod
           kubectl -n pregod rollout status deploy pregod-hub
           kubectl -n pregod rollout status deploy pregod-indexer
+          kubectl -n pregod rollout status deploy pregod-indexer-autocrawler

--- a/deploy/dev/deploy-indexer-autocrawler.yaml
+++ b/deploy/dev/deploy-indexer-autocrawler.yaml
@@ -1,16 +1,16 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: pregod-indexer
+  name: pregod-indexer-autocrawler
   namespace: pregod
 spec:
   progressDeadlineSeconds: 600
-  replicas: 6
+  replicas: 1
   revisionHistoryLimit: 10
   selector:
     matchLabels:
       app: pregod-indexer
-      tier: api
+      tier: autocrawler
   strategy:
     rollingUpdate:
       maxSurge: 25%
@@ -20,40 +20,24 @@ spec:
     metadata:
       labels:
         app: pregod-indexer
-        tier: api
+        tier: autocrawler
     spec:
       containers:
         - image: IMAGE
           imagePullPolicy: Always
           name: app
-          env:
-            - name: CONFIG_ENV
-              value: prod
           command:
             - ./indexer
-            - httpsvc
-          ports:
-            - containerPort: 3000
-              protocol: TCP
+            - autocrawler
           resources:
             requests:
-              memory: "200Mi"
-              cpu: "600m"
+              memory: "100Mi"
+              cpu: "100m"
             limits:
-              memory: "400Mi"
-              cpu: "1000m"
+              memory: "200Mi"
+              cpu: "250m"
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
-          readinessProbe:
-            tcpSocket:
-              port: 3000
-            initialDelaySeconds: 5
-            periodSeconds: 10
-          livenessProbe:
-            tcpSocket:
-              port: 3000
-            initialDelaySeconds: 15
-            periodSeconds: 20
           volumeMounts:
             - name: config
               mountPath: "/rss3-pregod/config"

--- a/deploy/prod/deploy-indexer-autocrawler.yaml
+++ b/deploy/prod/deploy-indexer-autocrawler.yaml
@@ -1,16 +1,16 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: pregod-indexer
+  name: pregod-indexer-autocrawler
   namespace: pregod
 spec:
   progressDeadlineSeconds: 600
-  replicas: 6
+  replicas: 1
   revisionHistoryLimit: 10
   selector:
     matchLabels:
       app: pregod-indexer
-      tier: api
+      tier: autocrawler
   strategy:
     rollingUpdate:
       maxSurge: 25%
@@ -20,7 +20,7 @@ spec:
     metadata:
       labels:
         app: pregod-indexer
-        tier: api
+        tier: autocrawler
     spec:
       containers:
         - image: IMAGE
@@ -31,29 +31,16 @@ spec:
               value: prod
           command:
             - ./indexer
-            - httpsvc
-          ports:
-            - containerPort: 3000
-              protocol: TCP
+            - autocrawler
           resources:
             requests:
-              memory: "200Mi"
+              memory: "400Mi"
               cpu: "600m"
             limits:
-              memory: "400Mi"
+              memory: "800Mi"
               cpu: "1000m"
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
-          readinessProbe:
-            tcpSocket:
-              port: 3000
-            initialDelaySeconds: 5
-            periodSeconds: 10
-          livenessProbe:
-            tcpSocket:
-              port: 3000
-            initialDelaySeconds: 15
-            periodSeconds: 20
           volumeMounts:
             - name: config
               mountPath: "/rss3-pregod/config"

--- a/indexer/main.go
+++ b/indexer/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log"
+	_ "net/http/pprof"
 
 	"github.com/NaturalSelectionLabs/RSS3-PreGod/indexer/pkg/api/arweave"
 	"github.com/NaturalSelectionLabs/RSS3-PreGod/indexer/pkg/api/gitcoin"
@@ -43,6 +44,22 @@ func RunHTTPServer(cmd *cobra.Command, args []string) error {
 		Handler:      router.InitRouter(),
 	}
 
+	defer logger.Logger.Sync()
+
+	srv.Start()
+
+	return nil
+}
+
+// runs every 10 minutes
+func RunAutoUpdater(cmd *cobra.Command, args []string) error {
+	logger.Info("Start refreshing recent visiters' data")
+
+	return autoupdater.RunRecentVisitQueue(context.Background())
+}
+
+func RunAutoCrawler(cmd *cobra.Command, args []string) error {
+	logger.Info("Start crawling arweave and gitcoin")
 	// arweave crawler
 	ar := arweave.NewArCrawler(
 		1,
@@ -61,18 +78,8 @@ func RunHTTPServer(cmd *cobra.Command, args []string) error {
 
 	go gc.PolygonStart()
 	go gc.EthStart()
-	go gc.ZkStart()
 
-	defer logger.Logger.Sync()
-
-	srv.Start()
-
-	return nil
-}
-
-// runs every 10 minutes
-func RunAutoUpdater(cmd *cobra.Command, args []string) error {
-	return autoupdater.RunRecentVisitQueue(context.Background())
+	return gc.ZkStart()
 }
 
 var rootCmd = &cobra.Command{Use: "indexer"}
@@ -85,6 +92,10 @@ func main() {
 	rootCmd.AddCommand(&cobra.Command{
 		Use:  "autoupdater",
 		RunE: RunAutoUpdater,
+	})
+	rootCmd.AddCommand(&cobra.Command{
+		Use:  "autocrawler",
+		RunE: RunAutoCrawler,
 	})
 
 	if err := rootCmd.Execute(); err != nil {

--- a/indexer/pkg/api/gitcoin/crawler.go
+++ b/indexer/pkg/api/gitcoin/crawler.go
@@ -249,7 +249,7 @@ func (gc *gitcoinCrawler) ZkStart() error {
 		select {
 		case <-gc.zk.Interrupt:
 			return nil
-		default:
+		case <-time.After(5 * time.Second):
 			gc.zksyncRun()
 		}
 	}
@@ -262,7 +262,7 @@ func (gc *gitcoinCrawler) EthStart() error {
 		select {
 		case <-gc.eth.Interrupt:
 			return nil
-		default:
+		case <-time.After(5 * time.Second):
 			gc.xscanRun(constants.NetworkIDEthereumMainnet)
 		}
 	}
@@ -275,7 +275,7 @@ func (gc *gitcoinCrawler) PolygonStart() error {
 		select {
 		case <-gc.polygon.Interrupt:
 			return nil
-		default:
+		case <-time.After(5 * time.Second):
 			gc.xscanRun(constants.NetworkIDPolygon)
 		}
 	}


### PR DESCRIPTION
1. `Indexer` still has mem leak (but much less than before). And it will auto restart when the mem limit is reached.
    - ![image](https://user-images.githubusercontent.com/10897528/160840805-82552188-8ddc-4f7b-b624-e76b3027cdda.png)
2. The crawler that start with HTTP server should exist only one at a time. So add a new `Deployment` with `replicas: 1` for the crawler.
    - So only the crawler will has mem leak
3. add `pprof` for debugging mem leak