### PR TITLE
feat: optimize autoupdater cronjob

### DIFF
--- a/deploy/dev/cronjob-indexer.yaml
+++ b/deploy/dev/cronjob-indexer.yaml
@@ -1,0 +1,49 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: pregod-indexer-autoupdater
+  namespace: pregod
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        activeDeadlineSeconds: 3600
+        spec:
+          containers:
+          - image: IMAGE
+            command:
+              - ./indexer
+              - autoupdater
+            imagePullPolicy: Always
+            name: autoupdater
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+            volumeMounts:
+              - name: config
+                mountPath: "/rss3-pregod/config"
+                readOnly: true
+              - name: mongo-ca
+                mountPath: "/rds-combined-ca-bundle.pem"
+                subPath: rds-combined-ca-bundle.pem
+                readOnly: true
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+          volumes:
+            - name: config
+              secret:
+                secretName: pregod
+            - name: mongo-ca
+              configMap:
+                name: rds-combined-ca-bundle.pem
+                items:
+                  - key: rds-combined-ca-bundle.pem
+                    path: rds-combined-ca-bundle.pem
+  schedule: "0 */6 * * *"
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/deploy/prod/cronjob-indexer.yaml
+++ b/deploy/prod/cronjob-indexer.yaml
@@ -1,0 +1,52 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: pregod-indexer-autoupdater
+  namespace: pregod
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        activeDeadlineSeconds: 3600
+        spec:
+          containers:
+          - image: IMAGE
+            env:
+              - name: CONFIG_ENV
+                value: prod
+            command:
+              - ./indexer
+              - autoupdater
+            imagePullPolicy: Always
+            name: autoupdater
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+            volumeMounts:
+              - name: config
+                mountPath: "/rss3-pregod/config"
+                readOnly: true
+              - name: mongo-ca
+                mountPath: "/rds-combined-ca-bundle.pem"
+                subPath: rds-combined-ca-bundle.pem
+                readOnly: true
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+          volumes:
+            - name: config
+              secret:
+                secretName: pregod
+            - name: mongo-ca
+              configMap:
+                name: rds-combined-ca-bundle.pem
+                items:
+                  - key: rds-combined-ca-bundle.pem
+                    path: rds-combined-ca-bundle.pem
+  schedule: "0 */6 * * *"
+  successfulJobsHistoryLimit: 3
+  suspend: false


### PR DESCRIPTION
The diffs:
- `concurrencyPolicy: Allow` -> `concurrencyPolicy: Forbid`
    - *The cron job does not allow concurrent runs; if it is time for a new job run and the previous job run hasn't finished yet, the cron job skips the new job run*
- `no limit` -> `activeDeadlineSeconds: 3600`
    - one job will run for 3600 secs for maximum
- `schedule: "*/10 * * * *"` -> `schedule: "0 */6 * * *"`
    - runs every 6 hours
- `restartPolicy: OnFailure` -> `restartPolicy: Never`
    - don't restart on failure