### PR TITLE
fix: job still restart onfailure

### DIFF
--- a/deploy/dev/cronjob-indexer.yaml
+++ b/deploy/dev/cronjob-indexer.yaml
@@ -8,6 +8,7 @@ spec:
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      backoffLimit: 0
       activeDeadlineSeconds: 21600
       template:
         spec:

--- a/deploy/prod/cronjob-indexer.yaml
+++ b/deploy/prod/cronjob-indexer.yaml
@@ -8,6 +8,7 @@ spec:
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      backoffLimit: 0
       activeDeadlineSeconds: 21600
       template:
         spec:


### PR DESCRIPTION
according to https://stackoverflow.com/questions/51657105/how-to-ensure-kubernetes-cronjob-does-not-restart-on-failure

We must set a `backoffLimit: 0` in combination with `restartPolicy: Never` in combination with `concurrencyPolicy: Forbid` to make sure the cronjob will not restart on failure